### PR TITLE
Fix wallet config

### DIFF
--- a/boltzr/src/chain/rpc_client.rs
+++ b/boltzr/src/chain/rpc_client.rs
@@ -41,7 +41,7 @@ impl RpcClient {
 
         Ok(Self {
             symbol,
-            endpoint: format!("http://{}:{}", config.host, config.port),
+            endpoint: format!("http://{}:{}/wallet/default", config.host, config.port),
             cookie: format!("Basic {}", BASE64_STANDARD.encode(auth)),
         })
     }

--- a/boltzr/src/payjoin/mod.rs
+++ b/boltzr/src/payjoin/mod.rs
@@ -66,6 +66,7 @@ async fn spawn_payjoin_receiver<'a>(
     let mut payjoin_proposal = match process_v2_proposal(receiver.clone()) {
         Ok(proposal) => proposal,
         Err(payjoin::receive::Error::ReplyToSender(e)) => {
+            dbg!(e);
             todo!("Handle recoverable error")
             // return Err(
             //     handle_recoverable_error(e, receiver, &self.config.v2()?.ohttp_relay).await

--- a/boltzr/src/payjoin/wallet.rs
+++ b/boltzr/src/payjoin/wallet.rs
@@ -1,4 +1,3 @@
-
 use std::sync::Arc;
 use std::str::FromStr;
 
@@ -24,8 +23,8 @@ impl BitcoindWallet {
     /// FIXME get client from config argument
     pub fn new() -> Result<Self> {
         let client = Client::new(
-            "127.0.0.1:18443",
-            Auth::CookieFile("../docker/regtest/data/core/cookies/.bitcoin-cookie".into()),
+            "127.0.0.1:18443/wallet/default",
+            Auth::CookieFile("docker/regtest/data/core/cookies/.bitcoin-cookie".into()),
         )?;
         Ok(Self { bitcoind: Arc::new(client) })
     }


### PR DESCRIPTION
Fix wallet config path relative to top-level directory. Make RPC clients work when there are multiple bitcoin-cli wallets.